### PR TITLE
remove illegal characters in video name

### DIFF
--- a/xvideos_dl/xvideos_dl.py
+++ b/xvideos_dl/xvideos_dl.py
@@ -200,12 +200,26 @@ def get_videos_by_playlist_id(pid: str, reset_cookie: bool) -> List[Video]:
     return videos
 
 
+def remove_illegal_chars(string: str) -> str:
+    illegal_chars: str = "\\/:*\"<>|;?!%^"
+
+    ret_str = str(string)
+    for ch in illegal_chars:
+        ret_str = ret_str.replace(ch, '_')
+
+    # remove non unicode characters
+    ret_str = bytes(ret_str, 'utf-8').decode('utf-8', 'ignore')
+
+    return ret_str
+
+
 def download(video: Video, dest: str, low: bool, overwrite: bool, reset_cookie: bool) -> None:
     save_dir = Path(dest) / (video.pname or video.uname)
     save_dir.mkdir(parents=True, exist_ok=True)
-    save_name = save_dir / f"{video.vname}(#{video.vid}).mp4"
+    video_name = remove_illegal_chars(video.vname)
+    save_name = save_dir / f"{video_name}(#{video.vid}).mp4"
     console.print(f"Video ID   : [white]{video.vid}[/]")
-    console.print(f"Video Name : [yellow]{video.vname}[/]")
+    console.print(f"Video Name : [yellow]{video_name}[/]")
     console.print(f"Destination: [white]{save_name.absolute()}[/]")
 
     done = 0


### PR DESCRIPTION
## Description

When the video name contains illegal characters, program will fail to create file on disk.  
A function that replace those illegal characters with `_` is added.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/lonsty/xvideos-dl/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/lonsty/xvideos-dl/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
